### PR TITLE
(refactor) Reduce UMD module by 1MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,19 +8,14 @@
     "webpack:build": "webpack -p",
     "webpack:watch": "webpack --watch &",
     "example": "cd examples/nodejs && npm start",
-
     "prestart": "npm run webpack:build",
     "start": "npm run example",
-
     "prewatch": "npm run webpack:watch",
     "watch": "npm run example",
-
     "pretest": "npm run webpack:watch",
     "test": "karma start karma.conf.js",
-
     "pretravis": "npm run webpack:build",
     "travis": "karma start karma.conf.js --single-run",
-
     "preheroku": "cd examples/nodejs && npm install",
     "heroku": "npm start"
   },
@@ -38,6 +33,8 @@
   },
   "dependencies": {
     "aws-sdk": "^2.38.0",
+    "buffer": "^5.0.6",
+    "crypto-browserify": "^3.11.0",
     "evaporate": "^2.1.0",
     "webpack": "^2.3.3"
   },

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,0 +1,79 @@
+// Lovingly borrowed and adapted from aws-sdk/lib/utils.js
+// for file size reasons.
+
+var crypto = require('crypto-browserify');
+var Buffer = require('buffer/').Buffer;
+
+function md5(data) {
+  return _hash('md5', data, 'base64');
+}
+
+function sha256(data) {
+  return _hash('sha256', data, 'hex');
+}
+
+function arraySliceFn(obj) {
+  var fn = obj.slice || obj.webkitSlice || obj.mozSlice;
+  return typeof fn === 'function' ? fn : null;
+}
+
+function _hash(algorithm, data, digest, callback) {
+  var hash = crypto.createHash(algorithm);
+
+  if (!digest) { digest = 'binary'; }
+  if (digest === 'buffer') { digest = undefined; }
+  if (typeof data === 'string') { data = new Buffer(data); }
+  var sliceFn = arraySliceFn(data);
+  var isBuffer = Buffer.isBuffer(data);
+
+  //Identifying objects with an ArrayBuffer as buffers
+  if (typeof ArrayBuffer !== 'undefined' && data && data.buffer instanceof ArrayBuffer) {
+    isBuffer = true;
+  }
+
+  if (callback && typeof data === 'object' && typeof data.on === 'function' && !isBuffer) {
+    data.on('data', function(chunk) { hash.update(chunk); });
+    data.on('error', function(err) { callback(err); });
+    data.on('end', function() { callback(null, hash.digest(digest)); });
+
+  } else if (callback && sliceFn && !isBuffer && typeof FileReader !== 'undefined') {
+    // this might be a File/Blob
+    var index = 0, size = 1024 * 512;
+    var reader = new FileReader();
+
+    reader.onerror = function() {
+      callback(new Error('Failed to read data.'));
+    };
+
+    reader.onload = function() {
+      var buf = new Buffer(new Uint8Array(reader.result));
+      hash.update(buf);
+      index += buf.length;
+      reader._continueReading();
+    };
+
+    reader._continueReading = function() {
+      if (index >= data.size) {
+        return callback(null, hash.digest(digest));
+      }
+
+      var back = index + size;
+      if (back > data.size) { back = data.size; }
+      reader.readAsArrayBuffer(sliceFn.call(data, index, back));
+    };
+
+    reader._continueReading();
+  } else {
+    if (typeof data === 'object' && !isBuffer) {
+      data = new Buffer(new Uint8Array(data));
+    }
+    var out = hash.update(data).digest(digest);
+    if (callback) { callback(null, out); }
+    return out;
+  }
+}
+
+module.exports = {
+  md5: md5,
+  sha256: sha256
+};

--- a/src/video-upload.js
+++ b/src/video-upload.js
@@ -1,6 +1,7 @@
 var Evaporate = require('evaporate');
-var AWS = require('aws-sdk');
 
+var md5 = require('./crypto').md5;
+var sha256 = require('./crypto').sha256;
 var ParamParser = require('./param-parser');
 var postJson = require('./post-json');
 var UIVideo = require('./components/video');
@@ -59,9 +60,9 @@ VideoUpload.prototype.prepareUpload = function prepareUpload() {
     bucket: this.bucket,
     awsSignatureVersion: '4',
     computeContentMd5: true,
-    logging: this.logging,
-    cryptoMd5Method: function (data) { return AWS.util.crypto.md5(data, 'base64'); },
-    cryptoHexEncodedHash256: function (data) { return AWS.util.crypto.sha256(data, 'hex'); },
+    logging: this.logging, // TODO -- fix this option!
+    cryptoMd5Method: md5,
+    cryptoHexEncodedHash256: sha256,
   }, this.overrides))
   .then(this.startUpload.bind(this));
 };


### PR DESCRIPTION
I extracted the signing logic from aws-sdk without ANY of the other
services (which bloated this module up to the original 2.6mb). The
minified bundled is now down to 350KB.