### PR TITLE
(refactor) Shrink UMD bundle from ~1.4mb to ~350kb

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "url": "https://github.com/BrightcoveOS/evaporate-brightcove.git"
   },
   "dependencies": {
-    "aws-sdk": "^2.38.0",
     "buffer": "^5.0.6",
     "crypto-browserify": "^3.11.0",
     "evaporate": "^2.1.0",

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -15,7 +15,9 @@ function sha256(data) {
 function _hash(algorithm, data, digest) {
   var hash = crypto.createHash(algorithm);
 
-  if (typeof data === 'string') { data = new Buffer(data); }
+  if (typeof data === 'string') {
+    data = new Buffer(data);
+  }
   var isBuffer = Buffer.isBuffer(data);
 
   //Identifying objects with an ArrayBuffer as buffers
@@ -26,8 +28,8 @@ function _hash(algorithm, data, digest) {
   if (typeof data === 'object' && !isBuffer) {
     data = new Buffer(new Uint8Array(data));
   }
-  var out = hash.update(data).digest(digest);
-  return out;
+
+  return hash.update(data).digest(digest);
 }
 
 module.exports = {

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -12,18 +12,10 @@ function sha256(data) {
   return _hash('sha256', data, 'hex');
 }
 
-function arraySliceFn(obj) {
-  var fn = obj.slice || obj.webkitSlice || obj.mozSlice;
-  return typeof fn === 'function' ? fn : null;
-}
-
-function _hash(algorithm, data, digest, callback) {
+function _hash(algorithm, data, digest) {
   var hash = crypto.createHash(algorithm);
 
-  if (!digest) { digest = 'binary'; }
-  if (digest === 'buffer') { digest = undefined; }
   if (typeof data === 'string') { data = new Buffer(data); }
-  var sliceFn = arraySliceFn(data);
   var isBuffer = Buffer.isBuffer(data);
 
   //Identifying objects with an ArrayBuffer as buffers
@@ -31,46 +23,11 @@ function _hash(algorithm, data, digest, callback) {
     isBuffer = true;
   }
 
-  if (callback && typeof data === 'object' && typeof data.on === 'function' && !isBuffer) {
-    data.on('data', function(chunk) { hash.update(chunk); });
-    data.on('error', function(err) { callback(err); });
-    data.on('end', function() { callback(null, hash.digest(digest)); });
-
-  } else if (callback && sliceFn && !isBuffer && typeof FileReader !== 'undefined') {
-    // this might be a File/Blob
-    var index = 0, size = 1024 * 512;
-    var reader = new FileReader();
-
-    reader.onerror = function() {
-      callback(new Error('Failed to read data.'));
-    };
-
-    reader.onload = function() {
-      var buf = new Buffer(new Uint8Array(reader.result));
-      hash.update(buf);
-      index += buf.length;
-      reader._continueReading();
-    };
-
-    reader._continueReading = function() {
-      if (index >= data.size) {
-        return callback(null, hash.digest(digest));
-      }
-
-      var back = index + size;
-      if (back > data.size) { back = data.size; }
-      reader.readAsArrayBuffer(sliceFn.call(data, index, back));
-    };
-
-    reader._continueReading();
-  } else {
-    if (typeof data === 'object' && !isBuffer) {
-      data = new Buffer(new Uint8Array(data));
-    }
-    var out = hash.update(data).digest(digest);
-    if (callback) { callback(null, out); }
-    return out;
+  if (typeof data === 'object' && !isBuffer) {
+    data = new Buffer(new Uint8Array(data));
   }
+  var out = hash.update(data).digest(digest);
+  return out;
 }
 
 module.exports = {


### PR DESCRIPTION
The minified AWS SDK on its own weighs in at 1.4mb (which was the size of our bundle minified too). The only thing we needed this dependency for was to sign the multipart upload requests to S3. Previous attempts at replacing it had failed.

After extensive digging (running an alternative JS crypto package inside the Evaporate crypto callbacks and comparing the results), I found that the critical things AWS SDK does is emulate Node.js buffers and crypto builtin packages.

This PR pulls in the AWS SDK crypto and buffer dependencies and the glue code from AWS SDK, and then simplifies it a little bit. The result is that signing uploads still works and we reduced the file size of the standalone UMD bundle by over 1MB. 

The biggest packages being used now are:

 * Evaporate (78kb) -- we're unlikely to get rid of this, since this module is currently a wrapper around Evaporate
 * browserify-crypto (48kb) -- might be possible to replace this with a thinner dependency, but we still need to make sure that ArrayBuffers are checksummed in an AWS compatible way, so level effort is high.
 * buffer (54kb) -- most likely candidate for refactoring away. It's unclear how much of this package we really need. It might be possible to conditionally load this package for old browsers that don't support ArrayBuffers properly.

This is a significant enough improvement