### PR TITLE
Push Based Ingest

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,17 +3,17 @@ Quick Start for Evaporate Brightcove
 
 At this end of this guide you'll have a working Node.js Express server that leverages Evaporate Brightcove.
 
-## 0. Obtain Credentials
-
-We'll need Brightcove API credentials and AWS credentials.
-
-### 0.0 Brightcove OAuth ID and Secret
+## Sign Up for a Brightcove Account
 
 If you plan to partner with Brightcove and build integrations with Video Cloud or other Brightcove products, [sign up for the partner program](http://go.brightcove.com/partner-inquiry). If you meet the criteria for becoming a partner, our team will set you up with an account
 
 If you're a Brightcove customer, you should already have access to Video Cloud.
 
-Either way, login to Video Cloud, and:
+### Brightcove OAuth ID and Secret
+
+We'll need Brightcove API credentials. The Brightcove API wraps the AWS STS service, such that you no longer need to manage nor configure an S3 bucket to use this service. Temporary credentials are issued for each upload which this module handles transparently.
+
+Inside Video Cloud:
 
  1. Click the ADMIN link in the Studio header.
  2. Click the API Authentication link. The API Authentication page will open displaying your current client registrations.
@@ -32,92 +32,6 @@ Either way, login to Video Cloud, and:
  7. Click save
  8. Store the Client ID and Secret for later steps
 
-### 0.1 AWS Credentials
-
-If you don't already have an AWS account, [signup for an account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) self-service now. Once you have an account, login and:
-
- 1. Go to [IAM](https://console.aws.amazon.com/iam/home)
- 2. Click on Users in the left navigation
- 3. Click the "Add User" button at the top of the page
- 4. Choose a username (probably the same name you used for Brightcove Client registration above)
- 5. Check the box for "Programmatic Access"
- 6. Click Next
- 7. Click Next again (don't pick any permissions here -- we'll add some later)
- 8. Click create user
- 9. Copy the Access Key ID and Secret Access Key for later.
-10. Click close
-11. Choose the user you created from the list of users
-12. Copy the "User ARN" value for later
-
-## Creating an S3 Bucket
-
-In your AWS account:
-
- 1. Go to the [S3 console](https://console.aws.amazon.com/s3/home?region=us-east-1#)
- 2. Click "Create bucket"
- 3. Enter a name
- 4. Choose a region close to you (remember this for a later step!)
- 5. Click Next
- 6. Don't set any properties -- click next
- 7. Don't set any user permissions nor public access -- click next
- 8. Click create bucket
-
-### Configure the Bucket for direct upload from Browsers (CORS)
-
- 1. Go to the [S3 console](https://console.aws.amazon.com/s3/home?region=us-east-1#)
- 9. Click your bucket on the list of buckets
- 10. In the popup, click on Permissions
- 11. Click on CORS configuration
- 12. Paste in the following:
-    ```
-    <?xml version="1.0" encoding="UTF-8"?>
-    <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-      <CORSRule>
-          <AllowedOrigin>*</AllowedOrigin>
-          <AllowedMethod>PUT</AllowedMethod>
-          <AllowedMethod>POST</AllowedMethod>
-          <AllowedMethod>DELETE</AllowedMethod>
-          <AllowedMethod>GET</AllowedMethod>
-          <ExposeHeader>ETag</ExposeHeader>
-          <AllowedHeader>*</AllowedHeader>
-      </CORSRule>
-    </CORSConfiguration>
-    ```
- 13. Click "Save"
-
-### Grant S3 permissions to your AWS User
-
-
- 1. Go to the [S3 console](https://console.aws.amazon.com/s3/home?region=us-east-1#)
- 9. Click your bucket on the list of buckets
- 10. In the popup, click on Permissions
- 11. Click on Bucket Policy
- 12. Paste in the following:
-    ```
-    {
-        "Version": "2012-10-17",
-        "Id": "EvaporateBrightcovePolicy",
-        "Statement": [
-            {
-                "Sid": "",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "<AWS User ARN>",
-                },
-                "Action": [
-                    "s3:AbortMultipartUpload",
-                    "s3:ListMultipartUploadParts",
-                    "s3:PutObject"
-                ],
-                "Resource": "arn:aws:s3::<S3 BUCKET NAME>/*"
-            }
-        ]
-    }
-    ```
- 13. Replace <AWS User ARN> with the ARN from above
- 14. Replace <S3 Bucket with the BUCKET NAME> from above
- 15. Save
-
 ## Get the example code working
 
 You must already have Node.js installed on your platform and have npm (or yarn) setup. The following steps will download this source code from github and work on the example code.
@@ -132,8 +46,18 @@ cp .env-sample .env
 
 Open .env in your text editor and replace all the values there with the credentials from above.
 
+## Start the example code
+
 ```
 npm start
 ```
 
-Then navigate to [localhost:5000](http://localhost:5000/) to see the code in action. At this point you should have a fully functional working sample app.
+This command watches the source code for the npm module and rebuilds as it changes; it also starts the Node.js example app, watching that directory for changes too. You can edit nearly any file in this repo and see the changes right away.
+
+## Upload Your First Video
+
+Then navigate to [localhost:5000](http://localhost:5000/) to see the code in action. If you're looking for a video to upload, try [coverr.co](http://coverr.co). You should see a new video appear in Video Cloud right away. Shortly, you'll see the thumbnail and be able to playback the video.
+
+## Fin
+
+At this point you should have a fully functional working sample app.

--- a/examples/nodejs/.env-sample
+++ b/examples/nodejs/.env-sample
@@ -2,8 +2,3 @@
 BRIGHTCOVE_ACCOUNT_ID=<Brightcove accountID>
 BRIGHTCOVE_CLIENT_ID=<Brightcove OAuth client ID>
 BRIGHTCOVE_CLIENT_SECRET=<Brightcove OAuth client secret>
-
-AWS_BUCKET=<Your S3 Bucket name>
-AWS_REGION=<The region for your S3 Bucket>
-AWS_ACCESS_KEY_ID=<Your AWS access key>
-AWS_SECRET_ACCESS_KEY=<YOur AWS Secret key>

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -10,7 +10,6 @@
     "node": "6.9.5"
   },
   "dependencies": {
-    "aws-sdk": "^2.7.21",
     "body-parser": "^1.15.2",
     "bunyan": "^1.8.10",
     "dotenv": "^4.0.0",

--- a/examples/nodejs/src/config.js
+++ b/examples/nodejs/src/config.js
@@ -16,10 +16,7 @@ var config = {
   },
 
   aws: {
-    region: 'us-west-1',
-    bucket: process.env.AWS_BUCKET,
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+    region: 'us-east-1',
   }
 };
 

--- a/examples/nodejs/src/controllers/ingest.js
+++ b/examples/nodejs/src/controllers/ingest.js
@@ -1,21 +1,20 @@
 'use strict';
 
-var aws = require('aws-sdk');
+var url = require('url');
 
 var brightcove = require('../brightcove');
 var config = require('../config');
+var db = require('../db');
 
 module.exports = function ingest(req, res) {
   var { videoId } = req.params;
   var { bucket, objectKey } = req.body;
-  var s3 = new aws.S3();
-  var signedUrl = s3.getSignedUrl('getObject', {Bucket: bucket, Key: objectKey, Expires: 3600});
   var accountId = config.brightcove.accountId;
 
+  var url = db.getApiRequestUrl(videoId);
+
   brightcove.post(`https://ingest.api.brightcove.com/v1/accounts/${accountId}/videos/${videoId}/ingest-requests`, {
-    master: {
-      url: signedUrl,
-    },
+    master: {url},
     profile: 'high-resolution',
   })
   .then((result) => res.json({result}))

--- a/examples/nodejs/src/controllers/sign.js
+++ b/examples/nodejs/src/controllers/sign.js
@@ -3,10 +3,12 @@
 var crypto = require('crypto');
 
 var config = require('../config');
+var db = require('../db');
 
 module.exports = function signHandler(req, res) {
   var {videoId} = req.params;
   var {to_sign, datetime} = req.query;
+  var awsSecretAccessKey = db.getSecretAccessKey(videoId);
 
   console.log(`Signing string '${to_sign}' with aws v4 signature algorithm`);
   console.log('Signing parameters:', {videoId, datetime, region: config.aws.region});
@@ -14,7 +16,7 @@ module.exports = function signHandler(req, res) {
   res.send(v4(
     to_sign,
     datetime.slice(0,8),
-    config.aws.secretAccessKey,
+    awsSecretAccessKey,
     config.aws.region,
     's3'
   ));

--- a/examples/nodejs/src/db.js
+++ b/examples/nodejs/src/db.js
@@ -1,0 +1,24 @@
+var store = {}; // Use a simple, dependency-free, in memory store.
+
+function getApiRequestUrl(videoId) {
+  return store[videoId].api_request_url;
+}
+
+function getSecretAccessKey(videoId) {
+  return store[videoId].secret_access_key;
+}
+
+function getSecurityToken(videoId) {
+  return store[videoId].session_token;
+}
+
+function save(videoId, response) {
+  store[videoId] = response;
+}
+
+module.exports = {
+  getSecretAccessKey,
+  getSecurityToken,
+  getApiRequestUrl,
+  save,
+};

--- a/src/video-upload.js
+++ b/src/video-upload.js
@@ -16,6 +16,7 @@ function VideoUpload(params) {
 
   // AWS Entities
   this.awsAccessKeyId = param.required('awsAccessKeyId');
+  this.sessionToken = param.required('sessionToken');
   this.bucket = param.required('bucket');
   this.objectKey = param.required('objectKey');
   this.region = param.required('region');
@@ -63,7 +64,8 @@ VideoUpload.prototype.prepareUpload = function prepareUpload() {
     bucket: this.bucket,
     awsSignatureVersion: '4',
     computeContentMd5: true,
-    logging: this.logging, // TODO -- fix this option!
+    sendCanonicalRequestToSignerUrl: true,
+    logging: true, // TODO: fix this parameter
     cryptoMd5Method: md5,
     cryptoHexEncodedHash256: sha256,
   }, this.overrides))
@@ -105,6 +107,12 @@ VideoUpload.prototype.startUpload = function startUpload(evap) {
     complete: this.complete.bind(this),
     uploadInitiated: this.onUploadInitiated,
     progress: this.progress.bind(this),
+    xAmzHeadersAtInitiate: {
+      'X-Amz-Security-Token': this.sessionToken,
+    },
+    xAmzHeadersCommon: {
+      'X-Amz-Security-Token': this.sessionToken,
+    },
   })
   .then(this.ingest.bind(this));
 };


### PR DESCRIPTION
@kfarr @twalling There were more changes than I anticipated, but I'm super happy with the results. The setup process is at least 50% easier now thanks to the CORS support in the DI bucket.

This PR:

 * Updates Evaporate Brightcove to send additional authentication headers to AWS (`X-Amz-Security-Token` from the DI Read Url API / AWS STS)
 * Adds API calls to DI Read Url API from the example app
 * Stores credentials in memory to make playing with the demo easier
 * Rewrite of the Quick Start guide to reflect easier onboarding and for clarity

Checklist:

 * [ ] Publish new code to Heroku
 * [ ] Publish v0.2.0 to npm