### PR TITLE
Ui for server errors

### DIFF
--- a/bcuploader.css
+++ b/bcuploader.css
@@ -1,12 +1,14 @@
 .bcuploader-root {position: relative;}
 
-
+.bcuploader-error.is-hidden,
 .bcuploader-preview.is-hidden {display: none;}
+
 .bcuploader-preview.is-shown {position: fixed; z-index: 2; top: 0; right: 0; left: 0; bottom: 0;}
 .bcuploader-preview_overlay {position: absolute; z-index: 1; background: black; opacity: 0.4; height: 100%; width: 100%; top:0; left: 0}
 .bcuploader-preview_player {position: absolute; z-index: 2; border: none; top: 20px; height: calc(100% - 40px); left: 20px; width: calc(100% - 40px);}
 .bcuploader-preview_close-button {position: absolute; z-index: 2; top:0; right: 0; cursor: hand; background: black; color: white; font-size: 14px;}
 
+.bcuploader-error,
 .bcuploader-video,
 .bcuploader-landing {background-color: #f7f7f9; border: 1px solid #e1e1e8; border-radius: 4px; padding: 30px; max-width: 400px; margin: auto; text-align: center;}
 .bcuploader-landing.is-dragover {border: 5px solid #9d9db4; padding: 26px; background-color: #d4e1f7;}
@@ -21,6 +23,8 @@
 .bcuploader-video.is-started {}
 .bcuploader-video.is-transcoding {}
 .bcuploader-video.is-preview {}
+
+.bcuploader-error,
 .bcuploader-video.is-error {color: #a94442; background-color: #f2dede; border-color: #ebccd1;}
 
 .bcuploader-video_file-name {position: relative; z-index:1; display: block; float: left;  text-align: left;}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -50,6 +50,25 @@ router.get('/upload', function(req, res) {
 
 ---
 
+#### `createVideoFailureText` (string)
+
+> Text shown to user when the server side implementation of the `createVideoEndpoint` crashes.
+
+ * Default: 'Oops! We weren\'t able to upload your video to our servers. Try a different video or try again later.'
+ * Any non-200 response should be enough to trigger this text appearing above the drag 'n drop zone.
+ * Consider translating this string if you want to serve a non-English target audience.
+
+```html
+<script>
+BCUploader({
+  createVideoFailureText: 'The server\'s on fire! Try uploading later.',
+  // ...
+});
+</script>
+```
+
+---
+
 #### `signUploadEndpoint` (string)
 
 > URL on server which signs S3 uploads using AWS secret key (without transmitting the secret key)

--- a/examples/nodejs/public/index.html
+++ b/examples/nodejs/public/index.html
@@ -19,9 +19,13 @@
   }
 
   @media screen and (min-width: 750px) {
+    .bcuploader-error {
+      margin-top: 1em;
+    }
+
     .bcuploader-landing {
       padding: 6em;
-      margin-top: 3em;
+      margin-top: 1em;
     }
   }
   </style>

--- a/src/bcuploader.js
+++ b/src/bcuploader.js
@@ -79,6 +79,11 @@ BCUploader.prototype.render = function render() {
 BCUploader.prototype.createVideo = function createVideo(file) {
   var self = this;
   return postJson(this.urls.createVideoEndpoint, {name: file.name})
+    .catch(function() {
+      // TODO: make this text customizable.
+      // TODO: fire onError callback
+      self.ui.showError('Oops! We weren\'t able to upload your video to our servers. Try a different video or try again later.');
+    })
     .then(function(response) {
       var params = Object.assign(response, self.callbacks, self.urls, {
         logging: self.logging,

--- a/src/bcuploader.js
+++ b/src/bcuploader.js
@@ -38,6 +38,10 @@ function BCUploader(params) {
 
   // wire up the UI and wait for user interaction
   this.landingText = param.optional('landingText', 'Drag Video Uploads Here');
+  this.createVideoFailureText = param.optional(
+    'createVideoFailureText',
+    'Oops! We weren\'t able to upload your video to our servers. Try a different video or try again later.'
+  );
   this.setupUI();
 
   // Video UI config
@@ -80,9 +84,7 @@ BCUploader.prototype.createVideo = function createVideo(file) {
   var self = this;
   return postJson(this.urls.createVideoEndpoint, {name: file.name})
     .catch(function() {
-      // TODO: make this text customizable.
-      // TODO: fire onError callback
-      self.ui.showError('Oops! We weren\'t able to upload your video to our servers. Try a different video or try again later.');
+      self.ui.showError(self.createVideoFailureText);
     })
     .then(function(response) {
       var params = Object.assign(response, self.callbacks, self.urls, {

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -13,6 +13,10 @@ Here's a block diagram of the logical hierarchy between the components:
  -------------------------------------------------------
  |                    Root                             |
  |     ------------------------------------------      |
+ |     |              Error                     |      |
+ |     ------------------------------------------      |
+ |                                                     |
+ |     ------------------------------------------      |
  |     |              Preview                   |      |
  |     ------------------------------------------      |
  |                                                     |
@@ -41,6 +45,16 @@ Here's a block diagram of the logical hierarchy between the components:
 
 This component is a container for the other components. It
 can have child components to added to it, or removed from it.
+
+### Error
+
+Displays errors related to the `createVideoEnpoint` or other problems
+not specific to the upload of one video. Initially hidden.
+
+### Preview
+
+Shows the video uploaded (if possible) when clicked on by the user.
+By default this is an overlay div that is initially empty and hidden.
 
 ### Landing
 

--- a/src/components/error.js
+++ b/src/components/error.js
@@ -1,0 +1,33 @@
+// Error Component
+// ===============
+//
+// This class is responsible to display generic errors related to whole uploader.
+
+function UIError(params) {
+  // Protect against forgetting the new keyword when instantiating objects
+  if (!(this instanceof UIError)) {
+    return new UIError(params);
+  }
+
+  this.message = null;
+  this.hidden = true;
+}
+
+UIError.prototype.showMessage = function showMessage(message) {
+  this.hidden = false;
+  this.message = message.toString();
+  this.render();
+};
+
+UIError.prototype.render = function render() {
+  var el = document.createElement('div');
+  el.className = 'bcuploader-error is-' + (this.hidden ? 'hidden' : 'shown');
+
+  if (this.message) {
+    el.innerHTML = this.message.toString();
+  }
+
+  return el;
+};
+
+module.exports = UIError;

--- a/src/components/landing.js
+++ b/src/components/landing.js
@@ -66,8 +66,6 @@ UILanding.prototype.render = function render() {
   heading.innerHTML = this.text;
   this.node.appendChild(heading);
 
-  // TODO -- create drag n drop area
-
   var input = document.createElement('input');
   input.type = 'file';
   input.classList.add('bcuploader-landing_file-input');

--- a/src/components/root.js
+++ b/src/components/root.js
@@ -5,6 +5,7 @@
 
 var UILanding = require('./landing');
 var UIPreview = require('./preview');
+var UIError = require('./error');
 
 function UIRoot(params) {
   // Protect against forgetting the new keyword when instantiating objects
@@ -19,12 +20,14 @@ function UIRoot(params) {
   });
   this.preview = new UIPreview({});
   this.videos = [];
+  this.error = new UIError({});
 }
 
 UIRoot.prototype.render = function render() {
   this.node.innerHTML = '';
   this.node.className = 'bcuploader-root';
 
+  this.node.appendChild(this.error.render());
   this.node.appendChild(this.preview.render());
   this.node.appendChild(this.landing.render());
 
@@ -40,6 +43,11 @@ UIRoot.prototype.render = function render() {
 
 UIRoot.prototype.addVideo = function addVideo(video) {
   this.videos.push(video);
+  this.render();
+};
+
+UIRoot.prototype.showError = function showError(message) {
+  this.error.showMessage(message);
   this.render();
 };
 

--- a/src/video-upload.js
+++ b/src/video-upload.js
@@ -119,9 +119,15 @@ VideoUpload.prototype.startUpload = function startUpload(evap) {
 };
 
 VideoUpload.prototype.ingest = function ingest() {
+  var self = this;
   return postJson(this.ingestUrl, {
     bucket: this.bucket,
     objectKey: this.objectKey,
+  })
+  .catch(function(response) {
+    var err = new Error(response.statusText);
+    err.response = response;
+    self.error(err);
   });
 };
 


### PR DESCRIPTION
The UI will now indicate that errors have happened for non-200 response codes from both the `createVideoEndpoint` and the `ingestUploadEndpoint`. Additionally, `ingestUploadEndpoint` server side errors now trigger the `onError` callback. Finally, a new configuration option `createVideoFailureText` makes the error message configurable.

Sadly, evaporate doesn't seem to bubble up failures (ex: 5XX response codes or connection issues) from what I've termed `signUploadEndpoint`, so I can't easily respond to that situation without an upstream change to evaporate or more poking.

Still this seems to be enough progress to warrant merging and publishing a new patch version to npm. Here's screenshots of both scenarios:

## `createVideoEndpoint` responds non-200

![createvideoupload-500](https://cloud.githubusercontent.com/assets/220106/26484974/e26304aa-41a9-11e7-98ed-4599e250ebb0.png)

## `ingestUploadEndpoint` responds non-200

![ingestuploadendpoint-500](https://cloud.githubusercontent.com/assets/220106/26485020/124fe8e0-41aa-11e7-86d1-aff56eb95965.png)
