### PR TITLE
(fix) Properly spell previewText so params are passed to UI

### DIFF
--- a/src/bcuploader.js
+++ b/src/bcuploader.js
@@ -46,7 +46,7 @@ function BCUploader(params) {
 
   // Video UI config
   this.videoUI = {
-    previewText: param.optional('preivewText', 'Preview'),
+    previewText: param.optional('previewText', 'Preview'),
     updatePreview: this.ui.preview.update.bind(this.ui.preview),
     onPreview: param.optional('onPreview', defaultPreviewAction),
     playerId: param.optional('playerId', 'default'),


### PR DESCRIPTION
Addresses: https://github.com/BrightcoveOS/evaporate-brightcove/issues/26